### PR TITLE
Update Lineage OS

### DIFF
--- a/TODO
+++ b/TODO
@@ -9,3 +9,5 @@ ToriOS  http://torios.top/
 Update:
 =======
 Budgie-remix to Ubuntu Budgie (https://ubuntubudgie.org/) on new release (17.04)
+CyanogenMod to Lineage OS (http://lineageos.org/)
+Cyanogen OS is done.


### PR DESCRIPTION
Cyanogen Inc has abandoned CyanogenMod and Cyanogen OS.  CyanogenMod is now forked under the name Lineage OS by the lead developer.