### PR TITLE
Fixes header 2 syntax in ReadMe markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Original source: http://futurist.se/gldt/
 
 https://github.com/FabioLolix/LinuxTimeline
 
-##CONTRIBUTING
+## CONTRIBUTING
 
 See CONTRIBUTING
 


### PR DESCRIPTION
Without the space, it is not recognized as a header (at least by GitHub).