### PR TITLE
Changed MCC Interim link to archived page

### DIFF
--- a/gldt.csv
+++ b/gldt.csv
@@ -548,7 +548,7 @@
 "N","Arch Linux 32","#0771a6","Arch","2017.11.08",,,"https://archlinux32.org/",,,,,,,,,
 "N","SystemRescueCD ","#508fee","Arch","2019.02.02",,,"https://www.system-rescue.org/","SystemRescue","2020.10.17","https://www.system-rescue.org/",,,,,,
 ,,,,,,,,,,,,,,,,
-"N","MCC Interim","#696a48",,"1992.2","1996.4.23",,"http://linux.about.com/cs/linux101/g/mccinterimlinux.htm",,,,,,,,,
+"N","MCC Interim","#696a48",,"1992.2","1996.4.23",,"https://web.archive.org/web/20120117220002/http://linux.about.com/cs/linux101/g/mccinterimlinux.htm",,,,,,,,,
 "N","TAMU","#3a34bc",,"1992.5","1994.10",,"http://www.oldlinux.org/Linux.old/distributions/TAMU/",,,,,,,,,
 "N","Yggdrasil","#668f53",,"1992.12.8","1995.5",,"http://en.wikipedia.org/wiki/Yggdrasil_Linux/GNU/X",,,,,,,,,
 "N","DLD","#9e9e9e",,"1993","1999.12",,"http://de.wikipedia.org/wiki/Deutsche_Linux-Distribution",,,,,,,,,


### PR DESCRIPTION
The page linked now redirects to a Lifewire page with no info on it whatsoever. I have made it so it now redirects to the version I presume it was meant to be.