### PR TITLE
Build images with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:22.04
+
+# @todo ImageMagick not working
+RUN apt-get update && apt-get -y install curl inkscape && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV GNUCLAD_VERSION="0.2.4"
+RUN GNUCLAD_VERSION_SHORT=`echo ${GNUCLAD_VERSION} | cut -d. -f1-2` && \
+    curl -o /tmp/gnuclad.tar.gz -fsSL "https://launchpad.net/gnuclad/trunk/${GNUCLAD_VERSION_SHORT}/+download/gnuclad-${GNUCLAD_VERSION}_amd64_debsource.tar.gz" && \
+    tar -C /tmp -xf /tmp/gnuclad.tar.gz && \
+    dpkg-deb --build /tmp/gnuclad-${GNUCLAD_VERSION}_amd64 && \
+    dpkg -i /tmp/gnuclad-${GNUCLAD_VERSION}_amd64.deb && \
+    rm -rf /tmp/gnuclad-${GNUCLAD_VERSION}_amd64 /tmp/gnuclad-${GNUCLAD_VERSION}_amd64.deb
+
+# Simple fix for inkscape
+RUN mkdir -p /.config/inkscape && chmod 777 /.config/inkscape
+
+WORKDIR /app
+CMD ["./build-docker.sh"]

--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ After you have installed gnuclad, to build just the svg, run:
 You can run the script `build.sh` to build the svg, png, and the tarball
 containing the source, ImageMagick is required to convert from svg to png.
 
+### Build with docker
+
+```bash
+# Build docker image and run it to build the distribution
+docker build -t linux-time-line .
+docker run -it --rm --name 'linux-time-line-run' --user 1000:1000 -v "${PWD}":/app linux-time-line
+
+# Do the same, but with docker-compose
+docker-compose build
+docker-compose run linux-time-line
+```
 
 ### Info archive
 

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+changeLinksInSVG() {
+    svgFile="${1}"
+
+    # Change links to distrowatch
+    #sed -i "s|https://distroware.gitlab.io/os/Linux/[a-z0-9]/|https://distrowatch.com/table.php?distribution=|g" ${svgFile}
+
+    # Append target blank
+    sed -i "s|xlink:href|target=\"_blank\" xlink:href|g" ${svgFile}
+}
+
+if [ ! -d dist ]; then
+    mkdir dist
+fi
+
+files=(
+    "ldt.csv"
+)
+for file in "${files[@]}"; do
+    # Generate SVG
+    gnuclad "${file}" "dist/${file/%csv/svg}" "${file/%csv/conf}"
+
+    # Change links in SVG
+    changeLinksInSVG "dist/${file/%csv/svg}"
+done
+# Doublicated, because creating a svg is faster than a image
+for file in "${files[@]}"; do
+    # Convert svg to image
+    inkscape --export-filename="dist/${file/%csv/png}" "dist/${file/%csv/svg}"
+done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.8'
+
+services:
+  linux-time-line:
+    build: .
+    user: 1000:1000
+    volumes:
+      - .:/app


### PR DESCRIPTION
I accidentally created a docker container to build the images. Very bad but it works. xD

What this does:
gnuclad is installed in an Ubuntu, then an SVG is created with gnuclad using script "build-docker.sh" and then converted with Inkscape.

Or simply:

```bash
docker-compose build
docker-compose run linux-time-line
```

Inkscape just because I was too lazy to find the bug for ImageMagick.

*Note: The line "Change links to distrowatch" in `build-docker.sh` is not to troll, it just made my life easier at the current moment. Just delete or keep it.*

Don't know if this pull request is interesting and it is definitely better to use the right system and construction tools.
