### PR TITLE
Add GrapheneOS

### DIFF
--- a/ldt.csv
+++ b/ldt.csv
@@ -723,7 +723,7 @@
 "##N","Android Wear","#a4c639","AOSP","2014.03.18",,,"https://distroware.gitlab.io/os/Linux/LinuxAndroid/a/android-wear","Wear OS","2018.03.15","https://distroware.gitlab.io/os/Linux/LinuxAndroid/a/android-wear",,,,,,
 "#N","CopperheadOS","#167C80","AOSP","2015.04.21",,,"https://distroware.gitlab.io/os/Linux/LinuxAndroid/c/copperhead-os",,,,,,,,,
 "##N","Project Brillo","#a4c639","AOSP","2015.05.28",,,"https://distroware.gitlab.io/os/Linux/LinuxAndroid/a/android-things","Android Things","2016.12.13","https://distroware.gitlab.io/os/Linux/LinuxAndroid/a/android-things",,,,,,
-"N","GrapheneOS","#80E0DA","AOSP","2019.4",,,"https://distroware.gitlab.io/os/LinuxAndroid/g/grapheneos/",,,,,,,,,
+"N","GrapheneOS","#212121","AOSP","2019.04.03",,,"https://distroware.gitlab.io/os/LinuxAndroid/g/grapheneos/",,,,,,,,,
 ,,,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,
 "#","Connectors",,,,,,,,,,,,,,,

--- a/ldt.csv
+++ b/ldt.csv
@@ -724,7 +724,6 @@
 "#N","CopperheadOS","#167C80","AOSP","2015.04.21",,,"https://distroware.gitlab.io/os/Linux/LinuxAndroid/c/copperhead-os",,,,,,,,,
 "##N","Project Brillo","#a4c639","AOSP","2015.05.28",,,"https://distroware.gitlab.io/os/Linux/LinuxAndroid/a/android-things","Android Things","2016.12.13","https://distroware.gitlab.io/os/Linux/LinuxAndroid/a/android-things",,,,,,
 "N","GrapheneOS","#80E0DA","AOSP","2019.4",,,"https://distroware.gitlab.io/os/LinuxAndroid/g/grapheneos/",,,,,,,,,
-"N","CalyxOS","#ff6633","AOSP","2018",,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,
 "#","Connectors",,,,,,,,,,,,,,,

--- a/ldt.csv
+++ b/ldt.csv
@@ -723,6 +723,8 @@
 "##N","Android Wear","#a4c639","AOSP","2014.03.18",,,"https://distroware.gitlab.io/os/Linux/LinuxAndroid/a/android-wear","Wear OS","2018.03.15","https://distroware.gitlab.io/os/Linux/LinuxAndroid/a/android-wear",,,,,,
 "#N","CopperheadOS","#167C80","AOSP","2015.04.21",,,"https://distroware.gitlab.io/os/Linux/LinuxAndroid/c/copperhead-os",,,,,,,,,
 "##N","Project Brillo","#a4c639","AOSP","2015.05.28",,,"https://distroware.gitlab.io/os/Linux/LinuxAndroid/a/android-things","Android Things","2016.12.13","https://distroware.gitlab.io/os/Linux/LinuxAndroid/a/android-things",,,,,,
+"N","GrapheneOS","#80E0DA","AOSP","2019.4",,,"https://distroware.gitlab.io/os/LinuxAndroid/g/grapheneos/",,,,,,,,,
+"N","CalyxOS","#ff6633","AOSP","2018",,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,
 "#","Connectors",,,,,,,,,,,,,,,


### PR DESCRIPTION
<!--

Will be added **ONLY** distributions that have a fullfilled page at the [info archive](https://distroware.gitlab.io/) 
and follow the [Timeline direction](https://github.com/FabioLolix/LinuxTimeline/issues/158)

The info archive code is both at:

* https://gitlab.com/Distroware/distroware.gitlab.io
* https://github.com/FabioLolix/distroware.gitlab.io

* The timeline direction can be discussed here: [Timeline direction discussion](https://github.com/FabioLolix/LinuxTimeline/issues/157)

->
