### PR TITLE
Discontinue Funtoo

### DIFF
--- a/ldt.csv
+++ b/ldt.csv
@@ -514,7 +514,7 @@
 "N","Papug","#0082ff","Enoch","2006.11","2012.12.31",,"https://distroware.gitlab.io/os/Linux/p/papug",,,,,,,,,
 "N","Calculate","#faa61a","Enoch","2007.6.6",,,"https://distroware.gitlab.io/os/Linux/c/calculate",,,,,,,,,
 "N","Toorox","#333333","Enoch","2007.11.28","2016.01.01",,"https://distroware.gitlab.io/os/Linux/t/toorox",,,,,,,,,
-"N","Funtoo","#333399","Enoch","2008.9",,,"https://distroware.gitlab.io/os/Linux/f/funtoo",,,,,,,,,
+"N","Funtoo","#333399","Enoch","2008.9","2024.7.26",,"https://distroware.gitlab.io/os/Linux/f/funtoo",,,,,,,,,
 "N","SystemRescueCD","#508fee","Enoch","2008.3.3","2019.02.02",,"https://distroware.gitlab.io/os/Linux/s/systemrescue",,,,,,,,,
 "N","Nova","#3d778a","Enoch","2009.2.12","2016",,"https://distroware.gitlab.io/os/Linux/n/nova",,,,,,,,,
 "N","Chromium OS","#5EAAB6","Enoch","2009.11.19",,,"https://distroware.gitlab.io/os/Linux/c/chromiumos",,,,,,,,,


### PR DESCRIPTION
Add discontinue date to Funtoo linux, based on a [discontinuation announcement](https://forums.funtoo.org/topic/5182-all-good-things-must-come-to-an-end/).
There is [another post](https://forums.funtoo.org/topic/5185-funtoo-continues-in-hobby-mode/) implying it is still being maintained in some limited capacity purely for personal use, but it is also marked as discontinued on [distrowatch](https://distrowatch.com/table.php?distribution=funtoo), make with that what you will.