### PR TITLE
Update ldt.csv to add AnduinOS

### DIFF
--- a/ldt.csv
+++ b/ldt.csv
@@ -270,6 +270,7 @@
 "#N","Maui Linux","#5997de","KDE Neon","2016.08.16","2020.03.05",,"https://www.mauilinux.org/",,,,,,,,,
 "N","Budgie-Remix","#404455","Ubuntu","2016.04.24",,,"https://distroware.gitlab.io/os/Linux/u/ubuntu-budgie","Ubuntu Budgie","2017.04.13","https://distroware.gitlab.io/os/Linux/u/ubuntu-budgie",,,,,,
 "N","Pop OS","#48B9C7","Ubuntu","2017.06.29",,,"https://distroware.gitlab.io/os/Linux/p/pop-os",,,,,,,,,
+"N","AnduinOS","#4a88eb","Ubuntu","2024.9.1",,,"https://www.anduinos.com",,,,,,,,,
 "#N","BeatriX","#c7bff0","Debian","2004.11.24","2005.1.29",,"http://en.wikipedia.org/wiki/BeatrIX",,,,,,,,,
 "N","Arco-Debian","#555555","Debian","2004.12.1","2013.06.14",,"https://distroware.gitlab.io/os/Linux/a/arco-debian","Arc-Live","2008.11.25","https://distroware.gitlab.io/os/Linux/a/arco-debian",,,,,,
 "N","MoLinux","#ad1d5a","Debian","2004.12.15","2011.12.24",,"https://distroware.gitlab.io/os/Linux/m/molinux",,,,,,,,,


### PR DESCRIPTION
<!--

Will be added **ONLY** distributions that have a fullfilled page at the [info archive](https://distroware.gitlab.io/) 
and follow the [Timeline direction](https://github.com/FabioLolix/LinuxTimeline/issues/158)

The info archive code is both at:

* https://gitlab.com/Distroware/distroware.gitlab.io
* https://github.com/FabioLolix/distroware.gitlab.io

* The timeline direction can be discussed here: [Timeline direction discussion](https://github.com/FabioLolix/LinuxTimeline/issues/157)

->
